### PR TITLE
chore: Save validation predictions table

### DIFF
--- a/framework-forecast-model-builder/CONTRIBUTING.md
+++ b/framework-forecast-model-builder/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ml-forecasting-incubator
+# Contributing to forecast-model-builder
 
-Thanks for taking the time to contribute to ml-forecasting-incubator!
+Thanks for taking the time to contribute to forecast-model-builder!
 
 ## Setting up a development environment
 

--- a/framework-forecast-model-builder/forecast_model_builder/utils.py
+++ b/framework-forecast-model-builder/forecast_model_builder/utils.py
@@ -83,7 +83,7 @@ def predict_baseline(
 
     Examples
     --------
-    >>> from ml_forecasting_incubator.utils import predict_baseline
+    >>> from forecast_model_builder.utils import predict_baseline
     >>> from snowflake.snowpark import Session
     >>> from snowflake.snowpark import types as T
     >>> session = Session.builder.getOrCreate()

--- a/framework-forecast-model-builder/inference.ipynb
+++ b/framework-forecast-model-builder/inference.ipynb
@@ -1,33 +1,4 @@
 {
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.11"
-  },
-  "lastEditStatus": {
-   "authorEmail": "kirk.mason@snowflake.com",
-   "authorId": "330147619279",
-   "authorName": "KMASON",
-   "lastEditTime": 1742872969761,
-   "notebookId": "exgz3t47rgulreu6w3xw",
-   "sessionId": "0af6eae7-10ee-4dec-a2a5-38429cd55fb0"
-  }
- },
- "nbformat_minor": 2,
- "nbformat": 4,
  "cells": [
   {
    "cell_type": "markdown",
@@ -658,7 +629,12 @@
    "source": [
     "# Write predictions to a Snowflake table.\n",
     "# Right now this is set up to overwrite the table if it already exists.\n",
-    "inference_result.write.save_as_table(INFERENCE_RESULT_TBL_NM, mode=\"overwrite\")\n",
+    "inference_result.write.save_as_table(\n",
+    "    INFERENCE_RESULT_TBL_NM,\n",
+    "    mode=\"overwrite\",\n",
+    "    comment='{\"origin\":\"sf_sit\", \"name\":\"sit_forecasting\", \"version\":{\"major\":1, \"minor\":0}, \"attributes\":{\"component\":\"inference\"}}',\n",
+    ")\n",
+    "\n",
     "print(\n",
     "    f\"Predictions written to table: {session_db}.{session_schema}.{INFERENCE_RESULT_TBL_NM}\"\n",
     ")\n",
@@ -668,5 +644,34 @@
     "session.table(INFERENCE_RESULT_TBL_NM).limit(3)"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  },
+  "lastEditStatus": {
+   "authorEmail": "kirk.mason@snowflake.com",
+   "authorId": "340032177737",
+   "authorName": "KMASON",
+   "lastEditTime": 1745508327584,
+   "notebookId": "gks23kx33gb5rjz54brg",
+   "sessionId": "92cfcca6-675e-421b-a33e-6e491cd3179a"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/framework-forecast-model-builder/modeling.ipynb
+++ b/framework-forecast-model-builder/modeling.ipynb
@@ -1351,7 +1351,7 @@
    "id": "ce110000-1111-2222-3333-ffffff000025",
    "metadata": {
     "codeCollapsed": true,
-    "collapsed": true,
+    "collapsed": false,
     "language": "python",
     "name": "_test_feature_eng"
    },
@@ -1421,12 +1421,14 @@
     "\n",
     "\n",
     "# Cache the final SDF\n",
-    "final_sdf_all = final_sdf_all.cache_result()"
+    "final_sdf_all = final_sdf_all.cache_result()\n",
+    "\n",
+    "print(\"Validation set feature engineering complete.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ce110000-1111-2222-3333-ffffff000024",
    "metadata": {
     "codeCollapsed": true,
@@ -1477,6 +1479,11 @@
     "        >= F.dateadd(\"day\", F.lit(-VALIDATION_DAYS), F.lit(last_time_period))\n",
     "    )\n",
     "\n",
+    "# Partition Count\n",
+    "inference_partition_count = (\n",
+    "    final_sdf_test.select(\"GROUP_IDENTIFIER_STRING\").distinct().count()\n",
+    ")\n",
+    "\n",
     "# Inspect the data\n",
     "dttm_boundaries = final_sdf_test.select(\n",
     "    F.min(TIME_PERIOD_COLUMN).alias(\"MIN_DTTM\"),\n",
@@ -1490,9 +1497,7 @@
     "print(f\"First time period in test set: {dttm_boundaries['MIN_DTTM']}\")\n",
     "print(f\"Last time period in test set:  {dttm_boundaries['MAX_DTTM']}\")\n",
     "if len(PARTITION_COLUMNS) > 0:\n",
-    "    print(\n",
-    "        f\"Total Partition Count: {final_sdf_test.select('GROUP_IDENTIFIER').distinct().count()}\"\n",
-    "    )\n",
+    "    print(f\"Total Partition Count: {inference_partition_count}\")\n",
     "else:\n",
     "    print(\"No partitions specified.\")\n",
     "final_sdf_test.show(2)"
@@ -1500,7 +1505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "ce110000-1111-2222-3333-ffffff000026",
    "metadata": {
     "codeCollapsed": true,
@@ -1599,9 +1604,6 @@
     ")\n",
     "\n",
     "# Stats related to inference dataset\n",
-    "inference_partition_count = (\n",
-    "    final_sdf_test.select(\"GROUP_IDENTIFIER_STRING\").distinct().count()\n",
-    ")\n",
     "print(f\"Inference data row count: {final_sdf_test.count()}\")\n",
     "print(f\"Largest partition record count: {largest_partition_record_count}\")\n",
     "print(f\"Number of partitions:   {inference_partition_count}\")\n",
@@ -1675,9 +1677,7 @@
     "# Cache result\n",
     "inference_result = inference_result.cache_result()\n",
     "\n",
-    "# Look at a couple rows of predictions\n",
-    "print(f\"Predictions (row count: {inference_result.count()})\")\n",
-    "inference_result.show(2)\n",
+    "# Switch back to the original warehouse\n",
     "session.use_warehouse(SESSION_WH)"
    ]
   },
@@ -1686,7 +1686,7 @@
    "execution_count": 15,
    "id": "66d4bf7f-b360-4e5e-976a-0a28f3c5e45b",
    "metadata": {
-    "codeCollapsed": true,
+    "codeCollapsed": false,
     "collapsed": false,
     "language": "python",
     "name": "_set_lead_if_multi_lead_modeling"
@@ -1697,7 +1697,55 @@
     "if train_separate_lead_models:\n",
     "    inference_result = inference_result.filter(\n",
     "        F.col(\"GROUP_IDENTIFIER_STRING\").endswith(\"LEAD_1\")\n",
-    "    )"
+    "    )\n",
+    "\n",
+    "# Write the validation scores to a Snowflake table in case the user just wants to re-run the model performance cells without re-running the model training cells.\n",
+    "inference_result.write.save_as_table(\n",
+    "    f\"VALIDATION_PREDS_FROM_{MODEL_NAME}\",\n",
+    "    mode=\"overwrite\",\n",
+    "    comment='{\"origin\":\"sf_sit\", \"name\":\"sit_forecasting\", \"version\":{\"major\":1, \"minor\":0}, \"attributes\":{\"component\":\"validation\"}}',\n",
+    ")\n",
+    "print(\n",
+    "    f\"Validation predictions saved to Snowflake table: {session_db_schema}.VALIDATION_PREDS_FROM_{MODEL_NAME}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdf02e1b-4ad1-4ddd-9383-44f58d47cfd3",
+   "metadata": {
+    "collapsed": false,
+    "name": "md_entry_point_explanation"
+   },
+   "source": [
+    "If users walk away from the notebook long enough for __the notebook session to end__ after it finishes running, they have the option to come back to the model evaluation section below at a later time. The __scored validation set__ was saved as a __Snowflake table__ after model training. So users can __re-activate__ this notebook and __re-run the evaluation cells__ below __without having to re-run inference on the validation set__. \n",
+    "\n",
+    "If the notebook has become inactive, and users wish to re-run the evalution cells below, they should follow these steps: \n",
+    "1. Click __Start__ in the upper right corner of the notebook to activate a new session\n",
+    "2. At the top of this notebook, __run all of the cells above__ the ___md_model_training___ markdown cell\n",
+    "3. Run the ____test_feature_eng___ and the ____test_split___ cells above. (No need to re-run the inference cell.)\n",
+    "4. Click the 3 dots in the upper right corner of the next cell (____validation_scores_sdf___) and select __\"Run all below\"__ to re-run all the evaluation cells.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce110000-1111-2222-3333-ffffff000005",
+   "metadata": {
+    "codeCollapsed": true,
+    "collapsed": false,
+    "language": "python",
+    "name": "_validation_scores_sdf"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a DataFrame from the saved table\n",
+    "validation_scores = session.table(f\"VALIDATION_SCORES_FOR_{MODEL_NAME}\")\n",
+    "\n",
+    "# Look at a couple rows of predictions\n",
+    "print(f\"Number of partitions:  {inference_partition_count}\")\n",
+    "print(f\"Validation row count:  {validation_scores.count()}\")\n",
+    "validation_scores.show(2)"
    ]
   },
   {
@@ -1713,7 +1761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "35beb03a-c85a-456a-b43b-486583cb217e",
    "metadata": {
     "codeCollapsed": true,
@@ -1743,7 +1791,7 @@
    "source": [
     "# Row-level metrics\n",
     "row_actual_v_fcst = (\n",
-    "    inference_result.with_column(\n",
+    "    validation_scores.with_column(\n",
     "        \"ABS_ERROR\", F.abs(F.col(\"ACTUAL\") - F.col(\"PREDICTED\"))\n",
     "    )\n",
     "    .with_column(\n",
@@ -1905,54 +1953,19 @@
     "language": "python",
     "name": "_plots"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-03-24 23:10:59.243 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.244 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.247 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.247 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.248 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.249 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.503 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.503 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.503 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.504 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.637 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.637 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.998 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.999 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.999 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:10:59.999 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:11:01.118 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n",
-      "2025-03-24 23:11:01.119 Thread 'MainThread': missing ScriptRunContext! This warning can be ignored when running in bare mode.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "DeltaGenerator()"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ------------------------------------------------------------------------------\n",
     "# Visualize individual partition actual vs pred on a time series line chart\n",
     "# ------------------------------------------------------------------------------\n",
     "# Select a single partition to visualize\n",
     "partitions = sorted(\n",
-    "    inference_result.select(\"GROUP_IDENTIFIER_STRING\").distinct().collect()\n",
+    "    validation_scores.select(\"GROUP_IDENTIFIER_STRING\").distinct().collect()\n",
     ")\n",
     "partition_choice = st.selectbox(\"Partition\", partitions)\n",
     "# Create a pandas dataframe\n",
     "partition_choice_df = (\n",
-    "    inference_result.filter(F.col(\"GROUP_IDENTIFIER_STRING\") == partition_choice)\n",
+    "    validation_scores.filter(F.col(\"GROUP_IDENTIFIER_STRING\") == partition_choice)\n",
     "    .sort(\"FUTURE_DTTM\")\n",
     "    .to_pandas()\n",
     ")\n",
@@ -2031,7 +2044,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "c6501d20-ec07-4a88-a158-7cae7b42ce8a",
    "metadata": {
     "codeCollapsed": true,
@@ -2073,7 +2086,23 @@
     }
    ],
    "source": [
-    "model_df = udtf_models.select(\n",
+    "# Establish model binary DataFrame\n",
+    "if \"udtf_models\" in globals():\n",
+    "    models_sdf = udtf_models\n",
+    "else:\n",
+    "    models_sdf = (\n",
+    "        session.table(f\"{MODEL_BINARY_STORAGE_TBL_NM}\")\n",
+    "        .filter(F.col(\"MODEL_NAME\") == MODEL_NAME)\n",
+    "        .filter(\n",
+    "            F.col(\"MODEL_VERSION\")\n",
+    "            == reg.get_model(qualified_model_name).default.version_name\n",
+    "        )\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"Feature Importances are for model version {reg.get_model(qualified_model_name).default.version_name} in table {MODEL_BINARY_STORAGE_TBL_NM}.\"\n",
+    "    )\n",
+    "\n",
+    "model_df = models_sdf.select(\n",
     "    \"MODEL_NAME\", \"GROUP_IDENTIFIER_STRING\", \"METADATA\"\n",
     ").to_pandas()\n",
     "\n",
@@ -2286,7 +2315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "23ee0b99-d373-42cf-a0f2-262a6c66411f",
    "metadata": {
     "codeCollapsed": true,
@@ -2346,7 +2375,7 @@
     "# Row-level metrics\n",
     "n_outliers = st.slider(\"Number of Outliers\", 5, 1000, 20)\n",
     "outlier_sdf = (\n",
-    "    inference_result.with_column(\n",
+    "    validation_scores.with_column(\n",
     "        \"ABS_ERROR\", F.abs(F.col(\"ACTUAL\") - F.col(\"PREDICTED\"))\n",
     "    )\n",
     "    .with_column(\n",
@@ -2384,9 +2413,9 @@
     "\n",
     "# Validation Actuals & Predictions Line Plot\n",
     "partition_df = (\n",
-    "    inference_result.filter(F.col(\"GROUP_IDENTIFIER_STRING\") == outlier_partition).sort(\n",
-    "        \"FUTURE_DTTM\"\n",
-    "    )\n",
+    "    validation_scores.filter(\n",
+    "        F.col(\"GROUP_IDENTIFIER_STRING\") == outlier_partition\n",
+    "    ).sort(\"FUTURE_DTTM\")\n",
     ").to_pandas()\n",
     "selected_date = pd.to_datetime(outlier_date)\n",
     "\n",
@@ -2436,7 +2465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "ce110000-1111-2222-3333-ffffff000034",
    "metadata": {
     "codeCollapsed": true,
@@ -2507,11 +2536,11 @@
   },
   "lastEditStatus": {
    "authorEmail": "kirk.mason@snowflake.com",
-   "authorId": "330147619279",
+   "authorId": "340032177737",
    "authorName": "KMASON",
-   "lastEditTime": 1742865999880,
-   "notebookId": "rezp3cxtl3cwvsxsctsk",
-   "sessionId": "102acce7-05d8-4d94-861a-3002417dcac0"
+   "lastEditTime": 1745509329596,
+   "notebookId": "3gkakoum5scrrntmgavo",
+   "sessionId": "5f6fbba0-890e-43a6-9c50-ea191831313d"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We save the validation predictions so that users can come back to an inactive notebook and re-run the evaluation cells without having to re-run the validation inference. A customer used the solution on a large job that took around 20 minutes to do validation inferencing. They left the notebook running and when they returned the session was inactive and they had to re-run the validation inferencing to inspect the model evaluation cells. They want to be able to revisit the model evaluation without having to re-run the validation inferencing.