### PR TITLE
fix: table name reference f"VALIDATION_PREDS_FROM_{MODEL_NAME}"

### DIFF
--- a/framework-forecast-model-builder/modeling.ipynb
+++ b/framework-forecast-model-builder/modeling.ipynb
@@ -1686,7 +1686,7 @@
    "execution_count": 15,
    "id": "66d4bf7f-b360-4e5e-976a-0a28f3c5e45b",
    "metadata": {
-    "codeCollapsed": false,
+    "codeCollapsed": true,
     "collapsed": false,
     "language": "python",
     "name": "_set_lead_if_multi_lead_modeling"
@@ -1723,8 +1723,8 @@
     "If the notebook has become inactive, and users wish to re-run the evalution cells below, they should follow these steps: \n",
     "1. Click __Start__ in the upper right corner of the notebook to activate a new session\n",
     "2. At the top of this notebook, __run all of the cells above__ the ___md_model_training___ markdown cell\n",
-    "3. Run the ____test_feature_eng___ and the ____test_split___ cells above. (No need to re-run the inference cell.)\n",
-    "4. Click the 3 dots in the upper right corner of the next cell (____validation_scores_sdf___) and select __\"Run all below\"__ to re-run all the evaluation cells.\n"
+    "3. Run the ___test_feature_eng___ and the ___test_split___ cells above. (No need to re-run the inference cell.)\n",
+    "4. Click the 3 dots in the upper right corner of the cell below (___validation_scores_sdf___) and select __\"Run all below\"__ to re-run all the evaluation cells.\n"
    ]
   },
   {
@@ -1739,8 +1739,10 @@
    },
    "outputs": [],
    "source": [
+    "# validation_scores_sdf cell\n",
+    "\n",
     "# Create a DataFrame from the saved table\n",
-    "validation_scores = session.table(f\"VALIDATION_SCORES_FOR_{MODEL_NAME}\")\n",
+    "validation_scores = session.table(f\"VALIDATION_PREDS_FROM_{MODEL_NAME}\")\n",
     "\n",
     "# Look at a couple rows of predictions\n",
     "print(f\"Number of partitions:  {inference_partition_count}\")\n",


### PR DESCRIPTION
Rafa Arranz noticed that in one cell in the modeling notebook we create a snowflake table named: **f"VALIDATION_PREDS_FROM_{MODEL_NAME}"**.

And then in the following cell we try to read from a table named: **f"VALIDATION_SCORES_FOR_{MODEL_NAME}"**. This is a typo. It should be looking for a table named: f"VALIDATION_PREDS_FROM_{MODEL_NAME}"