### PR TITLE
Resolve parsing bugs for semi-structured vars and improve metadata capture

### DIFF
--- a/helper-prompt-template-runner/prompt_parser.py
+++ b/helper-prompt-template-runner/prompt_parser.py
@@ -10,7 +10,7 @@ from snowflake.snowpark import Session
 from snowflake.cortex import complete
 from snowflake.snowpark.files import SnowflakeFile
 
-major, minor = 1, 5
+major, minor = 1, 6
 QUERY_TAG = {
     "origin": "sf_sit",
     "name": "prompt_template_runner",
@@ -58,7 +58,13 @@ class PromptParser:
         if column_vars:
             for var_name, col_name in column_vars.items():
                 if col_name in row_data:
-                    mapped_column_vals[var_name] = row_data.get(col_name, '')
+                    column_value = row_data.get(col_name)
+                    # Handle complex data types (dict, list) by serializing to JSON
+                    if isinstance(column_value, (dict, list)):
+                        mapped_column_vals[var_name] = json.dumps(column_value)
+                    else:
+                        # Convert to string, handling None values
+                        mapped_column_vals[var_name] = str(column_value) if column_value is not None else ''
 
         replace_dict = {**(literal_vars or {}), **(mapped_column_vals or {})} # Combine dictionaries if not empty
 
@@ -241,34 +247,81 @@ def extract_prompt(prompt_template_file: str) -> dict[str, Any]:
         except yaml.YAMLError as e:
             raise yaml.YAMLError(f"Error parsing YAML file {prompt_template_file}. Error: {e}")
 
+# def add_metadata(df: DataFrame, column: str, metadata: dict[str, Any]) -> DataFrame:
+#     """
+#     Adds metadata to a specified column in the DataFrame.
+
+#     If the metadata contains nested dictionaries, they are unnested and added as separate keys.
+
+#     Args:
+#         df (DataFrame): The DataFrame to which metadata will be added.
+#         column (str): The name of the column to which metadata will be added.
+#         metadata (dict[str, Any]): A dictionary containing metadata to be added. Nested dictionaries are supported.
+#     Returns:
+#         DataFrame: The DataFrame with the added metadata.
+#     """
+
+#     try:
+#         for key, value in metadata.items():
+
+#                 if value is None:
+#                     continue
+#                 elif key == 'model_options':
+#                     df = df.with_column(column,
+#                             F.sql_expr(f"OBJECT_INSERT({column}, '{key}', TO_JSON({value}))")
+#                             )
+#                 else:
+#                     df = df.with_column(
+#                         column,
+#                         F.sql_expr(f"OBJECT_INSERT({column}, '{key}', '{value}')")
+#                     )
+#         return df
+#     except Exception as e:
+#         raise Exception(f"Error adding metadata to DataFrame: {e}")
+
 def add_metadata(df: DataFrame, column: str, metadata: dict[str, Any]) -> DataFrame:
     """
     Adds metadata to a specified column in the DataFrame.
 
-    If the metadata contains nested dictionaries, they are unnested and added as separate keys.
+    This function replicates the original behavior where model_options
+    are treated as nested JSON objects.
 
     Args:
         df (DataFrame): The DataFrame to which metadata will be added.
         column (str): The name of the column to which metadata will be added.
-        metadata (dict[str, Any]): A dictionary containing metadata to be added. Nested dictionaries are supported.
+        metadata (dict[str, Any]): A dictionary containing metadata to be added.
+
     Returns:
         DataFrame: The DataFrame with the added metadata.
     """
-
     try:
         for key, value in metadata.items():
-
-                if value is None:
-                    continue
-                elif key == 'model_options':
-                    df = df.with_column(column,
-                            F.sql_expr(f"OBJECT_INSERT({column}, '{key}', TO_JSON({value}))")
-                            )
+            if value is None:
+                continue
+            elif key == 'model_options':
+                # Handle model_options as nested JSON - Fixed condition
+                if isinstance(value, dict):
+                    if value:  # Non-empty dictionary
+                        df = df.with_column(
+                            column,
+                            F.sql_expr(f"OBJECT_INSERT({column}, '{key}', PARSE_JSON('{json.dumps(value)}'))")
+                        )
+                    else:  # Empty dictionary
+                        df = df.with_column(
+                            column,
+                            F.sql_expr(f"OBJECT_INSERT({column}, '{key}', PARSE_JSON('{{}}'))")
+                        )
                 else:
+                    # Not a dict, treat as empty
                     df = df.with_column(
                         column,
-                        F.sql_expr(f"OBJECT_INSERT({column}, '{key}', '{value}')")
+                        F.sql_expr(f"OBJECT_INSERT({column}, '{key}', PARSE_JSON('{{}}'))")
                     )
+            else:
+                df = df.with_column(
+                    column,
+                    F.sql_expr(f"OBJECT_INSERT({column}, '{key}', '{value}')")
+                )
         return df
     except Exception as e:
         raise Exception(f"Error adding metadata to DataFrame: {e}")

--- a/helper-prompt-template-runner/register.sql
+++ b/helper-prompt-template-runner/register.sql
@@ -2,7 +2,7 @@ SET db_name = 'GENAI_UTILITIES';
 SET schema_name = 'UTILITIES';
 
 SET major = 1;
-SET minor = 5;
+SET minor = 6;
 SET COMMENT = concat('{"origin": "sf_sit",
             "name": "prompt_template_runner",
             "version": {"major": ',$major,', "minor": ',$minor,'}}');


### PR DESCRIPTION
Resolve bug when using semi-structured data to impute prompt variables. 
Unpacks model_options into distinct key-value pairs to replace prior method of dumping entire model_options in JSON string.