### PR TITLE
Fix: Enum key error + parameter for Snowflake data usage

### DIFF
--- a/helper-snowparser-for-dbt/README.md
+++ b/helper-snowparser-for-dbt/README.md
@@ -67,7 +67,8 @@ Below is an example of executing the stored procedure to parse dbt MetricFlow se
 CALL SNOWPARSER_DBT_SEMANTIC_YAML(
     manifest_file => '@DROPBOX/samples/manifest.json', -- Can be fully qualified stage
     semantic_view_name => 'my_semantic_view',
-    semantic_view_description => 'Semantic view about customers and orders'
+    semantic_view_description => 'Semantic view about customers and orders',
+    semantic_models => TO_ARRAY(['customers', 'orders']) -- Can select which semantic models to use. If omitted, all will be retained.
 );
 ```
 

--- a/helper-snowparser-for-dbt/README.md
+++ b/helper-snowparser-for-dbt/README.md
@@ -81,6 +81,7 @@ It is recommended to pass a list of dbt models to limit the number of dbt models
 CALL SNOWPARSER_DBT_GET_OBJECTS(
     manifest_file => '@DROPBOX/samples/manifest_wo_metricflow.json',
     dbt_models =>  TO_ARRAY(['customers','order_items', 'orders', 'stg_locations', 'stg_products'])
+    parse_snowflake_columns => TRUE -- Set to False to ONLY rely on column metadata in Manifest and not query for columns in associated Snowflake tables; Default is True
 );
 ```
 

--- a/helper-snowparser-for-dbt/dbt/semantics_schema.py
+++ b/helper-snowparser-for-dbt/dbt/semantics_schema.py
@@ -41,6 +41,7 @@ class AggregationType(Enum):
     count_distinct = "count_distinct"
     percentile = None # not implemented yet
     sum_boolean = "countif"
+    count = "count"
 
 
 @dataclass

--- a/helper-snowparser-for-dbt/setup.sql
+++ b/helper-snowparser-for-dbt/setup.sql
@@ -40,7 +40,8 @@ COPY FILES
 CREATE OR REPLACE PROCEDURE SNOWPARSER_DBT_SEMANTIC_YAML(
     manifest_file varchar,
     semantic_view_name varchar DEFAULT 'MY_SEMANTIC_VIEW',
-    semantic_view_description varchar DEFAULT 'MY_SEMANTIC_VIEW_DESCRIPTION'
+    semantic_view_description varchar DEFAULT 'MY_SEMANTIC_VIEW_DESCRIPTION',
+    semantic_models array DEFAULT []
 )
 RETURNS STRING
 LANGUAGE PYTHON
@@ -56,8 +57,8 @@ EXECUTE AS CALLER
 AS $$
 from semantic_manifest_parser import Manifest
 
-def get_yaml(session, manifest_file, semantic_view_name, semantic_view_description):
-    manifest = Manifest.manifest_from_json_file(session.connection, manifest_file,selected_models=[])
+def get_yaml(session, manifest_file, semantic_view_name, semantic_view_description, semantic_models):
+    manifest = Manifest.manifest_from_json_file(session.connection, manifest_file, selected_models=semantic_models)
 
     return manifest.generate_yaml(semantic_view_name, semantic_view_description)
 


### PR DESCRIPTION
PR resolves Key Errors that may arise from unknown Aggregation Types and adds `count` as an acceptable type. 

PR also adds a parameter to the `SNOWPARSER_DBT_GET_OBJECTS` utility to NOT crawl Snowflake tables for column metadata. If this is set to False, column metadata from only the Manifest.json will be used. If it's set to True, the default value, column metadata from Snowflake and Manifest.json will be used.