### PR TITLE
Support semantic model selection

### DIFF
--- a/helper-snowparser-for-dbt/README.md
+++ b/helper-snowparser-for-dbt/README.md
@@ -67,7 +67,8 @@ Below is an example of executing the stored procedure to parse dbt MetricFlow se
 CALL SNOWPARSER_DBT_SEMANTIC_YAML(
     manifest_file => '@DROPBOX/samples/manifest.json', -- Can be fully qualified stage
     semantic_view_name => 'my_semantic_view',
-    semantic_view_description => 'Semantic view about customers and orders'
+    semantic_view_description => 'Semantic view about customers and orders',
+    semantic_models => TO_ARRAY(['customers', 'orders']) -- Can select which semantic models to use. If omitted, all will be retained.
 );
 ```
 

--- a/helper-snowparser-for-dbt/setup.sql
+++ b/helper-snowparser-for-dbt/setup.sql
@@ -40,7 +40,8 @@ COPY FILES
 CREATE OR REPLACE PROCEDURE SNOWPARSER_DBT_SEMANTIC_YAML(
     manifest_file varchar,
     semantic_view_name varchar DEFAULT 'MY_SEMANTIC_VIEW',
-    semantic_view_description varchar DEFAULT 'MY_SEMANTIC_VIEW_DESCRIPTION'
+    semantic_view_description varchar DEFAULT 'MY_SEMANTIC_VIEW_DESCRIPTION',
+    semantic_models array DEFAULT []
 )
 RETURNS STRING
 LANGUAGE PYTHON
@@ -56,8 +57,8 @@ EXECUTE AS CALLER
 AS $$
 from semantic_manifest_parser import Manifest
 
-def get_yaml(session, manifest_file, semantic_view_name, semantic_view_description):
-    manifest = Manifest.manifest_from_json_file(session.connection, manifest_file,selected_models=[])
+def get_yaml(session, manifest_file, semantic_view_name, semantic_view_description, semantic_models):
+    manifest = Manifest.manifest_from_json_file(session.connection, manifest_file, selected_models=semantic_models)
 
     return manifest.generate_yaml(semantic_view_name, semantic_view_description)
 


### PR DESCRIPTION
Adds ability for users to explicitly provide semantic models to retain from Manifest json file. If omitted, all will be retained. 