### PR TITLE
Add column data type extraction

### DIFF
--- a/helper-snowparser-for-dbt/README.md
+++ b/helper-snowparser-for-dbt/README.md
@@ -69,6 +69,7 @@ CALL SNOWPARSER_DBT_SEMANTIC_YAML(
     semantic_view_name => 'my_semantic_view',
     semantic_view_description => 'Semantic view about customers and orders',
     semantic_models => TO_ARRAY(['customers', 'orders']) -- Can select which semantic models to use. If omitted, all will be retained.
+    parse_snowflake_columns => TRUE -- Default is True. Can omit. If True, queries Snowflake columns for correct data types.
 );
 ```
 

--- a/helper-snowparser-for-dbt/setup.sql
+++ b/helper-snowparser-for-dbt/setup.sql
@@ -5,7 +5,7 @@ SET schema_name = 'UTILITIES';
 USE DATABASE IDENTIFIER($db_name);
 USE SCHEMA IDENTIFIER($schema_name);
 SET major = 1;
-SET minor = 1;
+SET minor = 2;
 SET COMMENT = concat('{"origin": "sf_sit",
             "name": "snowparser_dbt",
             "version": {"major": ',$major,', "minor": ',$minor,'}}');
@@ -41,7 +41,8 @@ CREATE OR REPLACE PROCEDURE SNOWPARSER_DBT_SEMANTIC_YAML(
     manifest_file varchar,
     semantic_view_name varchar DEFAULT 'MY_SEMANTIC_VIEW',
     semantic_view_description varchar DEFAULT 'MY_SEMANTIC_VIEW_DESCRIPTION',
-    semantic_models array DEFAULT []
+    semantic_models array DEFAULT [],
+    parse_snowflake_columns boolean DEFAULT TRUE
 )
 RETURNS STRING
 LANGUAGE PYTHON
@@ -57,10 +58,10 @@ EXECUTE AS CALLER
 AS $$
 from semantic_manifest_parser import Manifest
 
-def get_yaml(session, manifest_file, semantic_view_name, semantic_view_description, semantic_models):
+def get_yaml(session, manifest_file, semantic_view_name, semantic_view_description, semantic_models, parse_snowflake_columns):
     manifest = Manifest.manifest_from_json_file(session.connection, manifest_file, selected_models=semantic_models)
 
-    return manifest.generate_yaml(semantic_view_name, semantic_view_description)
+    return manifest.generate_yaml(semantic_view_name, semantic_view_description, parse_snowflake_columns)
 
   $$;
 


### PR DESCRIPTION
Queries the `expr` of logical columns in Snowflake for data type. This mitigates issues such as assigning TEXT to a column that is likely BOOLEAN, for example.

Feature requested from the field.